### PR TITLE
fix: use supported hatchling version to fix release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Change the hatchling version to 1.26.3.

Our project is using METADATA version 2.4 and the latest hatchling version 1.27.0 does not support it causing the release to fail.

Reference - https://github.com/astral-sh/rye/issues/1446