### PR TITLE
fix(ci): correct workflow paths from scrapegraphai to toon

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,8 +3,8 @@ name: Code Quality Checks
 on:
   push:
     paths:
-      - 'scrapegraphai/**'
-      - '.github/workflows/pylint.yml'
+      - 'toon/**'
+      - '.github/workflows/code-quality.yml'
 
 jobs:
   quality:
@@ -19,13 +19,13 @@ jobs:
         run: uv sync --frozen
 
       - name: Run Ruff
-        run: uv run ruff check scrapegraphai
+        run: uv run ruff check toon
 
       - name: Run Black
-        run: uv run black --check scrapegraphai
+        run: uv run black --check toon
 
       - name: Run isort
-        run: uv run isort --check-only scrapegraphai
+        run: uv run isort --check-only toon
 
       - name: Analysing the code with pylint
         run: uv run poe pylint-ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "ruff>=0.8.0",
+    "black>=24.0.0",
+    "isort>=5.13.0",
+    "pylint>=3.3.0",
+    "poethepoet>=0.29.0",
 ]
 pydantic = [
     "pydantic>=1.10.0",
@@ -60,11 +65,9 @@ include = [
     "LICENSE",
 ]
 
-[tool.uv]
-dev-dependencies = [
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-]
+[tool.poe.tasks]
+pylint-ci = "pylint toon --output-format=text"
+pylint-score-ci = "pylint toon --score=yes"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
- Updated path triggers to monitor 'toon/**' instead of 'scrapegraphai/**'
- Fixed Ruff, Black, and isort commands to check 'toon' directory
- Corrected workflow reference to 'code-quality.yml'

[![CodeQL](https://github.com/ScrapeGraphAI/toonify/actions/workflows/codeql.yml/badge.svg)](https://github.com/ScrapeGraphAI/toonify/actions/workflows/codeql.yml)