### PR TITLE
Added support for Tuple data type encoding

### DIFF
--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -88,6 +88,17 @@ def test_encode_primitive_array():
     result = encode(data)
     assert result == 'items: [hello,"world, test",foo]'
 
+def test_encode_tuple_array():
+    """Test encoding of primitive arrays."""
+    # Number tuple
+    assert encode({'numbers': (1, 2, 3)}) == 'numbers: [1,2,3]'
+    
+    # String tuple
+    assert encode({'names': ('Alice', 'Bob')}) == 'names: [Alice,Bob]'
+    
+    # Mixed primitive tuple
+    assert encode({'mixed': (1, 'text', True, None)}) == 'mixed: [1,text,true,null]'
+
 
 def test_encode_array_delimiter():
     """Test different array delimiters."""

--- a/toon/encoder.py
+++ b/toon/encoder.py
@@ -184,7 +184,7 @@ def _encode_tuple(value: tuple) -> str:
     if not value:
         return '[]'
     
-    tuple_data = ','.join(str(v) for v in value)
+    tuple_data = ','.join(_encode_primitive_value(v) for v in value)
     tuple_string = f'[{tuple_data}]'
 
     return tuple_string

--- a/toon/encoder.py
+++ b/toon/encoder.py
@@ -117,9 +117,11 @@ def _encode_value(value: Any, level: int, opts: EncoderOptions) -> str:
         return _encode_array(value, level, opts)
     elif isinstance(value, dict):
         return _encode_object(value, level, opts)
+    elif isinstance(value, tuple):
+        return _encode_tuple(value)
     else:
         # Handle other types as null
-        return 'null'
+        raise NotImplementedError(f'Encoding for type {type(value)} is not implemented.')
 
 
 def _encode_object(obj: dict, level: int, opts: EncoderOptions) -> str:
@@ -176,6 +178,16 @@ def _encode_array(arr: list, level: int, opts: EncoderOptions) -> str:
     
     # Mixed array (list format)
     return _encode_list_array(arr, level, opts, key=None)
+
+def _encode_tuple(value: tuple) -> str:
+    """Encode a tuple."""
+    if not value:
+        return '[]'
+    
+    tuple_data = ','.join(str(v) for v in value)
+    tuple_string = f'[{tuple_data}]'
+
+    return tuple_string
 
 
 def _encode_array_with_key(key: str, arr: list, level: int, opts: EncoderOptions) -> str:

--- a/toon/encoder.py
+++ b/toon/encoder.py
@@ -120,7 +120,7 @@ def _encode_value(value: Any, level: int, opts: EncoderOptions) -> str:
     elif isinstance(value, tuple):
         return _encode_tuple(value)
     else:
-        # Handle other types as null
+        # Handle other types with NotImplementedError
         raise NotImplementedError(f'Encoding for type {type(value)} is not implemented.')
 
 


### PR DESCRIPTION
## Description
Previously, Toonify encoded unimplemented types as 'null'. This PR adds support for tuples and changes the behaviour so that an 'NotImplementedError' is raised for unknown types. Decoding tuples is handled as a list and does not require additional implementation.

## Related Issue
Not created

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
- [x] All tests pass
- [x] Added new tests for the changes
- [ ] Tested manually with examples

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings or errors introduced - Added a "NotImplementedError" for not implemented types